### PR TITLE
Fix REBA-SL brand colour not applying (Task #56)

### DIFF
--- a/client/src/hooks/useLeagueBranding.ts
+++ b/client/src/hooks/useLeagueBranding.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { extractColorsFromImage, TeamColors } from '@/lib/colorExtractor';
 
 const CACHE_KEY = 'league_branding_cache';
-const CACHE_VERSION = '2';
+const CACHE_VERSION = '3';
 const CACHE_DURATION = 7 * 24 * 60 * 60 * 1000;
 
 const DEFAULT_BRAND_COLORS: TeamColors = {

--- a/client/src/hooks/usePublicLeagueBranding.ts
+++ b/client/src/hooks/usePublicLeagueBranding.ts
@@ -10,6 +10,7 @@ interface LeagueBrandingData {
   accent_color: string | null;
   banner_url: string | null;
   logo_url: string | null;
+  brand_primary_colour: string | null;
 }
 
 const brandingCache = new Map<string, LeagueBrandingData | null>();
@@ -22,6 +23,7 @@ interface UsePublicLeagueBrandingBySlugOptions {
     primary_color?: string | null;
     secondary_color?: string | null;
     accent_color?: string | null;
+    brand_primary_colour?: string | null;
   } | null;
   enabled?: boolean;
 }
@@ -35,8 +37,7 @@ export function usePublicLeagueBrandingBySlug({
   const [isLoadingBranding, setIsLoadingBranding] = useState(false);
 
   const hasSufficientFallback = !!(fallbackLeague && (
-    (fallbackLeague.primary_color && fallbackLeague.secondary_color) ||
-    (fallbackLeague.banner_url || fallbackLeague.logo_url)
+    fallbackLeague.brand_primary_colour || fallbackLeague.primary_color
   ));
 
   useEffect(() => {
@@ -74,12 +75,13 @@ export function usePublicLeagueBrandingBySlug({
   }, [slug, enabled, hasSufficientFallback]);
 
   const source = brandingData || fallbackLeague;
+  const manualPrimary = source?.brand_primary_colour || source?.primary_color;
 
   const { colors, isLoading: isExtractingColors } = useLeagueBranding({
     slug,
     bannerUrl: source?.banner_url,
     logoUrl: source?.logo_url,
-    manualPrimaryColor: source?.primary_color,
+    manualPrimaryColor: manualPrimary,
     manualSecondaryColor: source?.secondary_color,
     manualAccentColor: source?.accent_color,
     enabled: !!source,
@@ -101,6 +103,7 @@ interface UsePublicLeagueBrandingByIdOptions {
     primary_color?: string | null;
     secondary_color?: string | null;
     accent_color?: string | null;
+    brand_primary_colour?: string | null;
   } | null;
   enabled?: boolean;
 }
@@ -114,8 +117,7 @@ export function usePublicLeagueBrandingById({
   const [isLoadingBranding, setIsLoadingBranding] = useState(false);
 
   const hasSufficientFallback = !!(fallbackLeague && (
-    (fallbackLeague.primary_color && fallbackLeague.secondary_color) ||
-    (fallbackLeague.banner_url || fallbackLeague.logo_url)
+    fallbackLeague.brand_primary_colour || fallbackLeague.primary_color
   ));
 
   useEffect(() => {
@@ -154,12 +156,13 @@ export function usePublicLeagueBrandingById({
 
   const source = brandingData || fallbackLeague;
   const slug = brandingData?.slug || fallbackLeague?.slug || undefined;
+  const manualPrimary = source?.brand_primary_colour || source?.primary_color;
 
   const { colors, isLoading: isExtractingColors } = useLeagueBranding({
     slug,
     bannerUrl: source?.banner_url,
     logoUrl: source?.logo_url,
-    manualPrimaryColor: source?.primary_color,
+    manualPrimaryColor: manualPrimary,
     manualSecondaryColor: source?.secondary_color,
     manualAccentColor: source?.accent_color,
     enabled: !!source,

--- a/client/src/pages/pages/league/[slug].tsx
+++ b/client/src/pages/pages/league/[slug].tsx
@@ -600,7 +600,10 @@ export default function LeaguePage() {
 
   const { colors: leagueBrandColors, brandingData: publicBrandingData } = usePublicLeagueBrandingBySlug({
     slug,
-    fallbackLeague: league,
+    fallbackLeague: league ? {
+      ...league,
+      brand_primary_colour: (league as any).brand_primary_colour ?? null,
+    } : null,
     enabled: !!slug,
   });
 


### PR DESCRIPTION
Three bugs were causing REBA-SL (and potentially other leagues with banner/logo images) to display stale or incorrect brand colours instead of their configured brand_primary_colour.

Changes made:

1. client/src/hooks/usePublicLeagueBranding.ts
   - Fixed hasSufficientFallback in both usePublicLeagueBrandingBySlug and usePublicLeagueBrandingById: removed banner_url/logo_url from the condition. Now only skips the API call if the fallback already has an explicit manual colour (brand_primary_colour or primary_color). This ensures the server endpoint is always consulted when no manual colour is pre-known.
   - Added brand_primary_colour to both fallbackLeague interface types.
   - Updated manualPrimaryColor derivation to prefer brand_primary_colour over primary_color (the canonical override column in Supabase).

2. client/src/pages/pages/league/[slug].tsx (line 604-611)
   - Updated the fallbackLeague passed to usePublicLeagueBrandingBySlug to explicitly spread league and include (league as any).brand_primary_colour, since brand_primary_colour is not part of the Drizzle-typed schema but is present on the raw Supabase select("*") response.

3. client/src/hooks/useLeagueBranding.ts
   - Bumped CACHE_VERSION from '2' to '3' to invalidate all stale localStorage entries (including any cached orange values) for all users on next page load.

No regressions expected: leagues without brand_primary_colour fall through to image extraction as before. Leagues with an explicit colour now have it respected regardless of whether they also have a banner or logo image.

Replit-Task-Id: 225a5d52-df54-4f43-9118-8d9eca5aa957