### PR TITLE
Update backend URL for swishassistant.com to use the correct service

### DIFF
--- a/client/src/lib/backendUrl.ts
+++ b/client/src/lib/backendUrl.ts
@@ -17,7 +17,7 @@ export function getPythonBackendUrl(): string {
 
   const hostname = window.location.hostname;
   if (hostname === 'swishassistant.com' || hostname.endsWith('.swishassistant.com')) {
-    return 'https://swish-python-backend.onrender.com';
+    return 'https://sab-backend.onrender.com';
   }
 
   return window.location.origin;


### PR DESCRIPTION
Update client-side configuration in `backendUrl.ts` to point `swishassistant.com` to the `sab-backend.onrender.com` service.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9223f22a-4012-47bf-9e39-e3f9c4916a97
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 00b33946-081b-489d-969a-e1007474e38b
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/79ee481f-439e-4c5e-84f5-cfdbb7adae89/9223f22a-4012-47bf-9e39-e3f9c4916a97/q78H8TP
Replit-Helium-Checkpoint-Created: true