### PR TITLE
Revert to direct Supabase calls for league data and player information

### DIFF
--- a/client/src/components/PlayerProfileContent.tsx
+++ b/client/src/components/PlayerProfileContent.tsx
@@ -1025,16 +1025,25 @@ export function PlayerProfileContent({ playerSlug, brandColorOverride, onBack }:
             );
             const userId = stats.length > 0 ? stats[0].user_id : null;
 
-            // Use service-role-backed endpoint for extra league info so that
-            // private child leagues (e.g. REBA SL age groups) resolve names
-            // and parent IDs correctly — the anon client is blocked by RLS.
             const extraLeagueInfoFetch: Promise<Record<string, { name: string; parent_league_id: string | null; age_group: string | null; stop: number | null }>> =
               extraLeagueIds.length > 0
-                ? fetch('/api/public/league-info', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ ids: extraLeagueIds }),
-                  }).then(r => r.ok ? r.json() : {}).catch(() => ({}))
+                ? supabase
+                    .from('leagues')
+                    .select('league_id, name, parent_league_id, age_group, stop')
+                    .in('league_id', extraLeagueIds)
+                    .then(({ data }) => {
+                      const result: Record<string, any> = {};
+                      (data || []).forEach((row: any) => {
+                        result[row.league_id] = {
+                          name: row.name,
+                          parent_league_id: row.parent_league_id || null,
+                          age_group: row.age_group || null,
+                          stop: row.stop ?? null,
+                        };
+                      });
+                      return result;
+                    })
+                    .catch(() => ({}))
                 : Promise.resolve({});
 
             const [gamesResp, publicLeaguesResp, extraLeagueInfoMap] = await Promise.all([

--- a/client/src/lib/leagueChildren.ts
+++ b/client/src/lib/leagueChildren.ts
@@ -1,3 +1,5 @@
+import { supabase } from "@/lib/supabase";
+
 export type LeagueChild = {
   league_id: string;
   name: string;
@@ -14,10 +16,12 @@ export async function fetchLeagueChildren(parentId: string): Promise<LeagueChild
   if (cache.has(parentId)) return cache.get(parentId)!;
   const p = (async () => {
     try {
-      const res = await fetch(`/api/public/league-children/${encodeURIComponent(parentId)}`);
-      if (!res.ok) return [];
-      const json = await res.json();
-      return Array.isArray(json?.children) ? (json.children as LeagueChild[]) : [];
+      const { data, error } = await supabase
+        .from("leagues")
+        .select("league_id, name, slug, logo_url, age_group, stop")
+        .eq("parent_league_id", parentId);
+      if (error) return [];
+      return (data || []) as LeagueChild[];
     } catch {
       return [];
     }

--- a/client/src/lib/leagueData.ts
+++ b/client/src/lib/leagueData.ts
@@ -1,36 +1,31 @@
-// Helpers that route reads against RLS-blocked tables (`teams`,
-// `team_stats`, `players`) through the server's service-role endpoint
-// so private (is_public=false) child leagues still roll up under their
-// public parent on the league page. The anon-key Supabase client gets
-// filtered by RLS on these tables and would otherwise return 0 rows
-// for private league_ids — see task #125.
-//
-// The server enforces the column projection per table (see the
-// `ALLOWED_LEAGUE_DATA_COLUMNS` allow-list in server/routes.ts) and
-// only returns rows whose league_id is itself public or a child of a
-// public parent. There is no caller-controlled column selection.
+import { supabase } from "@/lib/supabase";
 
 export type LeagueDataTable = "teams" | "team_stats" | "players";
+
+const TABLE_COLUMNS: Record<LeagueDataTable, string> = {
+  teams: "*",
+  team_stats: "*",
+  players: "id, full_name, slug",
+};
 
 export async function fetchLeagueData<T = any>(
   table: LeagueDataTable,
   leagueIds: string[],
-  parentLeagueId?: string,
+  _parentLeagueId?: string,
 ): Promise<{ data: T[] | null; error: Error | null }> {
   const ids = (leagueIds || []).filter((v) => typeof v === "string" && v.length > 0);
   if (ids.length === 0) return { data: [], error: null };
   try {
-    const res = await fetch("/api/public/league-data", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ table, leagueIds: ids, ...(parentLeagueId ? { parentLeagueId } : {}) }),
-    });
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      return { data: null, error: new Error(`league-data ${table} ${res.status}: ${body}`) };
+    const cols = TABLE_COLUMNS[table] || "*";
+    let query = supabase.from(table).select(cols) as any;
+    if (ids.length === 1) {
+      query = query.eq("league_id", ids[0]);
+    } else {
+      query = query.in("league_id", ids);
     }
-    const json = await res.json();
-    return { data: Array.isArray(json?.rows) ? (json.rows as T[]) : [], error: null };
+    const { data, error } = await query;
+    if (error) return { data: null, error: new Error(error.message) };
+    return { data: (data || []) as T[], error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err : new Error(String(err)) };
   }

--- a/client/src/pages/LeagueTeams.tsx
+++ b/client/src/pages/LeagueTeams.tsx
@@ -4,7 +4,6 @@ import { supabase } from "@/lib/supabase";
 import SwishLogo from "@/assets/Swish Assistant Logo.png";
 import { TeamLogo } from "@/components/TeamLogo";
 import { normalizeTeamName } from "@/lib/teamUtils";
-import { fetchLeagueData } from "@/lib/leagueData";
 import React from "react";
 
 interface League {
@@ -105,11 +104,10 @@ export default function LeagueTeams() {
 
         setLeague(leagueData);
 
-        // Fetch all teams via service-role endpoint (bypasses RLS for private leagues)
-        const { data: allTeams, error: teamsError } = await fetchLeagueData<{ team_id: string; name: string }>(
-          "teams",
-          [leagueData.league_id],
-        );
+        const { data: allTeams, error: teamsError } = await supabase
+          .from("teams")
+          .select("team_id, name")
+          .eq("league_id", leagueData.league_id);
 
         if (teamsError) {
           console.error("Error fetching teams:", teamsError);
@@ -122,16 +120,10 @@ export default function LeagueTeams() {
           return;
         }
 
-        // Fetch all player stats via service-role endpoint (bypasses RLS for private leagues)
-        const { data: allPlayerStats, error: statsError } = await fetch("/api/public/player-stats", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ leagueIds: [leagueData.league_id], page: 0, pageSize: 1000 }),
-        }).then(async (r) => {
-          if (!r.ok) return { data: null, error: new Error(`player-stats ${r.status}`) };
-          const j = await r.json();
-          return { data: j.rows ?? [], error: null };
-        }).catch((e) => ({ data: null, error: e }));
+        const { data: allPlayerStats, error: statsError } = await supabase
+          .from("player_stats")
+          .select("*")
+          .eq("league_id", leagueData.league_id);
 
         if (statsError) {
           console.error("Error fetching player stats:", statsError);

--- a/client/src/pages/pages/league/[slug].tsx
+++ b/client/src/pages/pages/league/[slug].tsx
@@ -1260,20 +1260,14 @@ export default function LeaguePage() {
         const fetchLeagueId = getDataLeagueId(slug, league.league_id);
         const parentChildIdsForTeamStats = childCompetitions.map(c => c.league_id);
         const isParentTeamStatsFetch = parentChildIdsForTeamStats.length > 0;
-        // For parent leagues, route team_stats through the service-role
-        // endpoint so private (is_public=false) children still roll up.
-        // The anon-key client is filtered by RLS on `team_stats`.
         let rawTeamStats: any[] | null = null;
         let error: any = null;
-        if (isParentTeamStatsFetch) {
-          const result = await fetchLeagueData<any>("team_stats", parentChildIdsForTeamStats);
-          rawTeamStats = result.data;
-          error = result.error;
-        } else {
-          const result = await db
-            .from("team_stats")
-            .select("*")
-            .eq("league_id", fetchLeagueId);
+        {
+          const idsToFetch = isParentTeamStatsFetch ? parentChildIdsForTeamStats : [fetchLeagueId];
+          const q = idsToFetch.length === 1
+            ? db.from("team_stats").select("*").eq("league_id", idsToFetch[0])
+            : db.from("team_stats").select("*").in("league_id", idsToFetch);
+          const result = await q;
           rawTeamStats = result.data;
           error = result.error;
         }
@@ -2484,26 +2478,15 @@ export default function LeaguePage() {
         }
         debugLog("📊 Step 1: Fetching all player_stats for league_id:", statsLeagueId, "isParent:", isParentFetch);
 
-        // For parent leagues, route the roster fetch through the
-        // service-role endpoint so players from private (is_public=false)
-        // children are included. The anon-key client is filtered by RLS
-        // on the `players` table.
         let rosterData: any[] | null = null;
-        if (isParentFetch && parentChildIds.length > 0) {
-          const result = await fetchLeagueData<any>("players", parentChildIds);
-          if (result.error) {
-            console.error("Error fetching parent roster via league-data:", result.error);
-          }
-          rosterData = result.data;
-        } else {
-          const { data, error: rosterError } = await supabase
-            .from("players")
-            .select("id, full_name, slug")
-            .eq("league_id", statsLeagueId);
-          if (rosterError) {
-            console.error("Error fetching roster:", rosterError);
-          }
-          rosterData = data;
+        {
+          const rosterIds = isParentFetch && parentChildIds.length > 0 ? parentChildIds : [statsLeagueId];
+          const rosterQ = rosterIds.length === 1
+            ? supabase.from("players").select("id, full_name, slug").eq("league_id", rosterIds[0])
+            : supabase.from("players").select("id, full_name, slug").in("league_id", rosterIds);
+          const { data: rosterResult, error: rosterError } = await rosterQ;
+          if (rosterError) console.error("Error fetching roster:", rosterError);
+          rosterData = rosterResult;
         }
 
         const slugLookup = new Map<string, string>();
@@ -2535,33 +2518,12 @@ export default function LeaguePage() {
               let data: any[] | null = null;
               let error: any = null;
 
-              if (isParentFetch) {
-                // Route through the service-role endpoint so private child
-                // leagues (e.g. REBA SL age groups) are included — the anon
-                // Supabase client is blocked by RLS for is_public=false rows.
-                // Pass parentLeagueId so the server can validate the children
-                // even when the parent itself has is_public=false (REBA SL).
-                const res = await fetch("/api/public/player-stats", {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
-                    leagueIds: parentChildIds,
-                    page,
-                    pageSize,
-                    parentLeagueId: league.league_id,
-                  }),
-                });
-                if (res.ok) {
-                  const json = await res.json();
-                  data = json.rows ?? null;
-                } else {
-                  error = { message: `player-stats HTTP ${res.status}` };
-                }
-              } else {
-                const result = await db
-                  .from("player_stats")
-                  .select("*")
-                  .eq("league_id", statsLeagueId)
+              {
+                const psIds = isParentFetch && parentChildIds.length > 0 ? parentChildIds : [statsLeagueId];
+                const psQ = psIds.length === 1
+                  ? db.from("player_stats").select("*").eq("league_id", psIds[0])
+                  : db.from("player_stats").select("*").in("league_id", psIds);
+                const result = await psQ
                   .order("player_id", { ascending: true, nullsFirst: false })
                   .range(page * pageSize, (page + 1) * pageSize - 1);
                 data = result.data;
@@ -2659,17 +2621,12 @@ export default function LeaguePage() {
 
     const calculateStandingsForLeague = async (leagueId: string, parentLeagueId?: string): Promise<{standings: any[], poolAStandings: any[], poolBStandings: any[], hasPools: boolean}> => {
       try {
-        // Route the `teams` fetch through the service-role endpoint so
-        // private (is_public=false) child leagues — which RLS hides from
-        // the anon client — still produce standings rows on the parent
-        // league page. Pass parentLeagueId to bypass is_public gating.
-        const { data: allTeams, error: teamsError } = await fetchLeagueData<{ team_id: string; name: string }>(
-          "teams",
-          [leagueId],
-          parentLeagueId,
-        );
+        const { data: allTeams, error: teamsError } = await db
+          .from("teams")
+          .select("team_id, name")
+          .eq("league_id", leagueId);
         if (teamsError) {
-          console.error("Error fetching teams via league-data:", teamsError);
+          console.error("Error fetching teams:", teamsError);
         }
 
         const { data: gameResults, error: gameResultsError } = await db
@@ -2807,13 +2764,10 @@ export default function LeaguePage() {
     // Calculate team standings using team_stats table first, fallback to player_stats
     const calculateStandingsWithTeamStats = async (leagueId: string, playerStats: any[], parentLeagueId?: string) => {
       try {
-        // Use service-role endpoint so private child leagues (is_public=false)
-        // are still included — the anon Supabase client is blocked by RLS.
-        const { data: allTeams, error: teamsError } = await fetchLeagueData<{ team_id: string; name: string }>(
-          "teams",
-          [leagueId],
-          parentLeagueId,
-        );
+        const { data: allTeams, error: teamsError } = await db
+          .from("teams")
+          .select("team_id, name")
+          .eq("league_id", leagueId);
 
         if (teamsError || !allTeams || allTeams.length === 0) {
           console.error("Error fetching teams:", teamsError);
@@ -3007,13 +2961,10 @@ export default function LeaguePage() {
       try {
         setIsLoadingStandings(true);
 
-        // Use service-role endpoint so private child leagues (is_public=false)
-        // are still included — the anon Supabase client is blocked by RLS.
-        const { data: allTeams, error: teamsError } = await fetchLeagueData<{ team_id: string; name: string }>(
-          "teams",
-          [leagueId],
-          parentLeagueId,
-        );
+        const { data: allTeams, error: teamsError } = await db
+          .from("teams")
+          .select("team_id, name")
+          .eq("league_id", leagueId);
 
         if (teamsError || !allTeams || allTeams.length === 0) {
           console.error("Error fetching teams:", teamsError);

--- a/client/src/utils/teamLogoCache.ts
+++ b/client/src/utils/teamLogoCache.ts
@@ -1,3 +1,4 @@
+import { supabase } from "@/lib/supabase";
 import { fetchLeagueChildren } from "@/lib/leagueChildren";
 import { DEBUG, debugLog } from "./debug";
 
@@ -21,18 +22,15 @@ async function getParentLeagueId(leagueId: string): Promise<string | null> {
   }
   const fetchPromise = (async () => {
     try {
-      const res = await fetch('/api/public/league-info', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ids: [leagueId] }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        const parentId = data[leagueId]?.parent_league_id || null;
-        parentLeagueCache.set(leagueId, parentId);
-        parentLeagueFetching.delete(leagueId);
-        return parentId;
-      }
+      const { data } = await supabase
+        .from('leagues')
+        .select('parent_league_id')
+        .eq('league_id', leagueId)
+        .single();
+      const parentId = data?.parent_league_id || null;
+      parentLeagueCache.set(leagueId, parentId);
+      parentLeagueFetching.delete(leagueId);
+      return parentId;
     } catch {
       // fall through to null
     }


### PR DESCRIPTION
Replace API calls to service-role endpoints with direct Supabase client queries in various frontend components and utility files, restoring direct data fetching for league and player information.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9223f22a-4012-47bf-9e39-e3f9c4916a97
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 36ca59b1-21a6-43c2-bb83-450e597b6e1d
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/79ee481f-439e-4c5e-84f5-cfdbb7adae89/9223f22a-4012-47bf-9e39-e3f9c4916a97/awhLwWr
Replit-Helium-Checkpoint-Created: true