### PR TITLE
Update file upload to bypass serverless functions in production

### DIFF
--- a/client/src/components/LeagueAdmin/upload-section-la.tsx
+++ b/client/src/components/LeagueAdmin/upload-section-la.tsx
@@ -4,7 +4,6 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { getPythonBackendUrl } from "@/lib/backendUrl";
 
 const UploadSectionLA = ({ leagues }: any) => {
   const { user } = useAuth();
@@ -111,8 +110,15 @@ const UploadSectionLA = ({ leagues }: any) => {
 
     try {
       setStatusMessage("🔄 Parsing file...");
+      // In dev: use the Express proxy (/api/parse) to avoid CORS.
+      // In production: call the Python backend directly so Vercel serverless
+      // functions aren't involved (they crash on long-running upstream calls).
+      const backendUrl = import.meta.env.VITE_BACKEND_URL as string | undefined;
+      const parseUrl = (import.meta.env.DEV || !backendUrl)
+        ? `/api/parse`
+        : `${backendUrl.replace(/\/$/, "")}/api/parse`;
       const resp = await fetch(
-        `/api/parse`,
+        parseUrl,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Modify the upload section to directly call the backend URL in production environments, bypassing the Vercel serverless function, and use the local proxy in development.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 9223f22a-4012-47bf-9e39-e3f9c4916a97
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: a99f8b92-365d-41b0-82b4-b04f8513519a
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/79ee481f-439e-4c5e-84f5-cfdbb7adae89/9223f22a-4012-47bf-9e39-e3f9c4916a97/lka8I2d
Replit-Helium-Checkpoint-Created: true