### PR TITLE
Improve player stats display by handling team name variations

### DIFF
--- a/client/src/components/InlineGameDetail.tsx
+++ b/client/src/components/InlineGameDetail.tsx
@@ -254,16 +254,22 @@ export function InlineGameDetail({
             sturnovers: r.turnovers ?? r.sturnovers,
           });
 
-          const hasSide = boxRows.some((r: any) => r.side === "1" || r.side === "2");
+          const norm = (s: string | null | undefined) => (s || "").trim().toLowerCase();
+          const homeNorm = norm(homeName);
+          const awayNorm = norm(awayName);
+          // Use side field when present on a row, fall back to case-insensitive
+          // team_name match. This handles the mixed case where one team has side
+          // values in v_box_score and the other does not (e.g. Just Cardio).
+          const matchesHome = (r: any) =>
+            r.side === "1" || (!r.side && norm(r.team_name || r.team) === homeNorm);
+          const matchesAway = (r: any) =>
+            r.side === "2" || (!r.side && norm(r.team_name || r.team) === awayNorm);
+
           const allStats: PlayerStat[] = boxRows.map(toStat);
-          const homeStats = (hasSide
-            ? boxRows.filter((r: any) => r.side === "1")
-            : boxRows.filter((r: any) => (r.team_name || r.team) === homeName)
-          ).map(toStat).sort((a, b) => (b.spoints || 0) - (a.spoints || 0));
-          const awayStats = (hasSide
-            ? boxRows.filter((r: any) => r.side === "2")
-            : boxRows.filter((r: any) => (r.team_name || r.team) === awayName)
-          ).map(toStat).sort((a, b) => (b.spoints || 0) - (a.spoints || 0));
+          const homeStats = boxRows.filter(matchesHome)
+            .map(toStat).sort((a, b) => (b.spoints || 0) - (a.spoints || 0));
+          const awayStats = boxRows.filter(matchesAway)
+            .map(toStat).sort((a, b) => (b.spoints || 0) - (a.spoints || 0));
 
           setHomePlayerStats(homeStats);
           setAwayPlayerStats(awayStats);


### PR DESCRIPTION
Update the game detail component to correctly filter player statistics by team, implementing case-insensitive matching and a fallback for rows lacking side information to ensure all player data is displayed.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: a98d7b4f-7ae7-485a-8fce-4e24e64a6ce5
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 33c0df1c-4d15-439a-b976-cd288d9b2fb3
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/79ee481f-439e-4c5e-84f5-cfdbb7adae89/a98d7b4f-7ae7-485a-8fce-4e24e64a6ce5/Oqf8H7B
Replit-Helium-Checkpoint-Created: true