### PR TITLE
Fix away team showing coach name and blank box score (#260) — revised

### DIFF
--- a/client/src/components/GameDetailModal.tsx
+++ b/client/src/components/GameDetailModal.tsx
@@ -132,15 +132,65 @@ export default function GameDetailModal({ gameId, isOpen, onClose }: GameDetailM
             const detail = gameDetail as any;
             if (detail.league_id) setLeagueId(detail.league_id);
             gameDate = detail.match_time || gameDate;
+
+            // Detect when v_game_detail returns a coach name instead of a real team name.
+            // This happens when home_team / away_team equals a coach field on the same row.
+            const looksLikeCoach = (name: string) =>
+              !!name && (name === detail.home_coach || name === detail.away_coach);
+
+            let detailHomeName: string = detail.home_team || "";
+            let detailAwayName: string = detail.away_team || "";
+
+            if (looksLikeCoach(detailHomeName) || looksLikeCoach(detailAwayName)) {
+              const { data: tsRows } = await supabase
+                .from("team_stats")
+                .select("name, tot_spoints")
+                .eq("game_key", gameId);
+
+              if (tsRows && tsRows.length > 0) {
+                const teamNames = Array.from(
+                  new Set((tsRows as any[]).map((r: any) => r.name).filter(Boolean))
+                ) as string[];
+
+                if (teamNames.length >= 2) {
+                  const scoreFor = (name: string) =>
+                    (tsRows as any[])
+                      .filter((r: any) => r.name === name)
+                      .reduce((acc: number, r: any) => acc + (r.tot_spoints || 0), 0);
+
+                  const s0 = scoreFor(teamNames[0]);
+                  const s1 = scoreFor(teamNames[1]);
+                  const hs = detail.home_score ?? 0;
+                  const as_ = detail.away_score ?? 0;
+
+                  if (s0 === hs && s1 === as_) {
+                    detailHomeName = teamNames[0];
+                    detailAwayName = teamNames[1];
+                  } else if (s1 === hs && s0 === as_) {
+                    detailHomeName = teamNames[1];
+                    detailAwayName = teamNames[0];
+                  } else {
+                    detailHomeName = teamNames[0];
+                    detailAwayName = teamNames[1];
+                  }
+                } else if (teamNames.length === 1) {
+                  if (!looksLikeCoach(detailHomeName)) {
+                    detailAwayName = teamNames[0];
+                  } else {
+                    detailHomeName = teamNames[0];
+                  }
+                }
+              }
+            }
             
-            if (detail.home_team) teamsInfo[detail.home_team] = detail.home_score || 0;
-            if (detail.away_team) teamsInfo[detail.away_team] = detail.away_score || 0;
+            if (detailHomeName) teamsInfo[detailHomeName] = detail.home_score || 0;
+            if (detailAwayName) teamsInfo[detailAwayName] = detail.away_score || 0;
             
             // Build team_stats-like data for downstream use
             const fakeTeamStats = [];
-            if (detail.home_team) {
+            if (detailHomeName) {
               fakeTeamStats.push({
-                name: detail.home_team, tot_spoints: detail.home_score,
+                name: detailHomeName, tot_spoints: detail.home_score,
                 p1_score: detail.home_q1, p2_score: detail.home_q2, p3_score: detail.home_q3, p4_score: detail.home_q4,
                 tot_sfieldgoalsmade: detail.home_fgm, tot_sfieldgoalsattempted: detail.home_fga, tot_sfieldgoalspercentage: detail.home_fg_pct,
                 tot_sthreepointersmade: detail.home_3pm, tot_sthreepointersattempted: detail.home_3pa, tot_sthreepointerspercentage: detail.home_3p_pct,
@@ -156,9 +206,9 @@ export default function GameDetailModal({ gameId, isOpen, onClose }: GameDetailM
                 coach: detail.home_coach, league_id: detail.league_id, game_key: detail.game_key,
               });
             }
-            if (detail.away_team) {
+            if (detailAwayName) {
               fakeTeamStats.push({
-                name: detail.away_team, tot_spoints: detail.away_score,
+                name: detailAwayName, tot_spoints: detail.away_score,
                 p1_score: detail.away_q1, p2_score: detail.away_q2, p3_score: detail.away_q3, p4_score: detail.away_q4,
                 tot_sfieldgoalsmade: detail.away_fgm, tot_sfieldgoalsattempted: detail.away_fga, tot_sfieldgoalspercentage: detail.away_fg_pct,
                 tot_sthreepointersmade: detail.away_3pm, tot_sthreepointersattempted: detail.away_3pa, tot_sthreepointerspercentage: detail.away_3p_pct,
@@ -275,6 +325,26 @@ export default function GameDetailModal({ gameId, isOpen, onClose }: GameDetailM
             if (teamsFromStats.length > 0 && !selectedTeam) {
               setSelectedTeam(teamsFromStats[0]);
             }
+
+            // Remap teamStatsFromDb entries whose names don't match the confirmed
+            // box-score team names. This fixes the case where v_game_detail returned
+            // a coach name that the looksLikeCoach check didn't catch.
+            setTeamStatsFromDb(prev => {
+              if (prev.length === 0) return prev;
+              const normStr = (s: string) => (s || "").trim().toLowerCase();
+              const hasAllMatch = prev.every(row =>
+                teamsFromStats.some(t => normStr(t) === normStr(row.name))
+              );
+              if (hasAllMatch) return prev; // names already correct — no-op
+
+              // Remap by matching tot_spoints → updatedTeamsInfo score
+              return prev.map(row => {
+                if (teamsFromStats.some(t => normStr(t) === normStr(row.name))) return row;
+                const pts = row.tot_spoints ?? 0;
+                const corrected = teamsFromStats.find(t => updatedTeamsInfo[t] === pts);
+                return corrected ? { ...row, name: corrected } : row;
+              });
+            });
           }
           
           setGameStats(processedStats);

--- a/client/src/components/InlineGameDetail.tsx
+++ b/client/src/components/InlineGameDetail.tsx
@@ -161,10 +161,55 @@ export function InlineGameDetail({
         if (d.league_id) setLeagueId(d.league_id);
         if (d.competitionname) setCompetitionName(d.competitionname);
 
-        const homeName = d.home_team || "";
-        const awayName = d.away_team || "";
+        let homeName = d.home_team || "";
+        let awayName = d.away_team || "";
         const homeScore = d.home_score ?? 0;
         const awayScore = d.away_score ?? 0;
+
+        // Detect when v_game_detail returns a coach name instead of a real team name.
+        // This happens when home_team / away_team equals the coach fields on the same row.
+        const looksLikeCoach = (name: string) =>
+          !!name && (name === d.home_coach || name === d.away_coach);
+
+        if (looksLikeCoach(homeName) || looksLikeCoach(awayName)) {
+          const { data: tsRows } = await supabase
+            .from("team_stats")
+            .select("name, tot_spoints")
+            .eq("game_key", gameKey);
+
+          if (tsRows && tsRows.length > 0) {
+            const teamNames = Array.from(
+              new Set(tsRows.map((r: any) => r.name).filter(Boolean))
+            ) as string[];
+
+            if (teamNames.length >= 2) {
+              const scoreFor = (name: string) =>
+                (tsRows as any[])
+                  .filter((r: any) => r.name === name)
+                  .reduce((acc: number, r: any) => acc + (r.tot_spoints || 0), 0);
+
+              const s0 = scoreFor(teamNames[0]);
+              const s1 = scoreFor(teamNames[1]);
+
+              if (s0 === homeScore && s1 === awayScore) {
+                homeName = teamNames[0];
+                awayName = teamNames[1];
+              } else if (s1 === homeScore && s0 === awayScore) {
+                homeName = teamNames[1];
+                awayName = teamNames[0];
+              } else {
+                homeName = teamNames[0];
+                awayName = teamNames[1];
+              }
+            } else if (teamNames.length === 1) {
+              if (!looksLikeCoach(homeName)) {
+                awayName = teamNames[0];
+              } else {
+                homeName = teamNames[0];
+              }
+            }
+          }
+        }
 
         const info: GameInfo = {
           date: d.match_time || new Date().toISOString(),
@@ -255,6 +300,61 @@ export function InlineGameDetail({
           });
 
           const norm = (s: string | null | undefined) => (s || "").trim().toLowerCase();
+
+          // --- Name correction using box score as ground truth ---
+          // v_game_detail sometimes has a coach name where a team name should be.
+          // If the current homeName/awayName don't appear in the box score team
+          // names, replace with whatever the box score actually contains.
+          const hasSideField = boxRows.some((r: any) => r.side === "1" || r.side === "2");
+          if (!hasSideField) {
+            const boxTeamNames = Array.from(
+              new Set(boxRows.map((r: any) => (r.team_name || r.team || "") as string).filter(Boolean))
+            ) as string[];
+
+            const homeInBox = boxTeamNames.some(t => norm(t) === norm(homeName));
+            const awayInBox = boxTeamNames.some(t => norm(t) === norm(awayName));
+
+            if (!homeInBox || !awayInBox) {
+              // One or both names are wrong — figure out the correct ones
+              const scoreFor = (t: string) =>
+                boxRows.filter((r: any) => norm(r.team_name || r.team) === norm(t))
+                  .reduce((acc: number, r: any) => acc + (r.points ?? r.spoints ?? 0), 0);
+
+              if (!homeInBox && awayInBox) {
+                const candidates = boxTeamNames.filter(t => norm(t) !== norm(awayName));
+                if (candidates.length > 0) homeName = candidates[0];
+              } else if (!awayInBox && homeInBox) {
+                const candidates = boxTeamNames.filter(t => norm(t) !== norm(homeName));
+                if (candidates.length > 0) awayName = candidates[0];
+              } else if (boxTeamNames.length >= 2) {
+                // Both wrong — try score matching, fall back to position order
+                const s0 = scoreFor(boxTeamNames[0]);
+                const s1 = scoreFor(boxTeamNames[1]);
+                if (s0 === homeScore && s1 === awayScore) {
+                  homeName = boxTeamNames[0]; awayName = boxTeamNames[1];
+                } else if (s1 === homeScore && s0 === awayScore) {
+                  homeName = boxTeamNames[1]; awayName = boxTeamNames[0];
+                } else {
+                  homeName = boxTeamNames[0]; awayName = boxTeamNames[1];
+                }
+              }
+
+              // Re-apply corrected names to all downstream state
+              const correctedInfo: GameInfo = {
+                ...info,
+                hometeam: homeName,
+                awayteam: awayName,
+                teams: [homeName, awayName].filter(Boolean),
+                teamScores: { [homeName]: homeScore, [awayName]: awayScore },
+              };
+              setGameInfo(correctedInfo);
+              if (onGameInfoLoaded) onGameInfoLoaded(correctedInfo);
+              if (homeName) setHomeTeamStats(makeTeamRow("home", homeName));
+              if (awayName) setAwayTeamStats(makeTeamRow("away", awayName));
+            }
+          }
+          // --- End name correction ---
+
           const homeNorm = norm(homeName);
           const awayNorm = norm(awayName);
           // Use side field when present on a row, fall back to case-insensitive


### PR DESCRIPTION
## Problem
`v_game_detail.away_team` (and sometimes `home_team`) returns a coach name instead of the real team name for some games (confirmed game: PDF_2026072318351_86_9). The first attempt used a coach-field equality check (`home_team === home_coach`) which failed in practice because the coach field in the view does not always equal the bad team-name value.

## Root-cause insight
The `looksLikeCoach` check was too narrow. The real-world data had a wrong team name that didn't exactly match any coach field, so the early correction never fired and the bad name propagated everywhere.

## Revised fix — box score as ground truth

### InlineGameDetail.tsx
After fetching `v_box_score` rows, extract the distinct team names that actually appear in the box score. If `homeName` or `awayName` from `v_game_detail` are absent from those names (meaning they are wrong — coach name, blank, etc.), replace them with the real box-score names, mapping home/away by score when possible, falling back to position order. Then re-call `setGameInfo`, `setHomeTeamStats`, `setAwayTeamStats` with the corrected names so the tab labels, quarter-score table, and player filtering all use the right values. The `side` field shortcut is preserved (skips correction when all rows have explicit side "1"/"2").

### GameDetailModal.tsx
After processing box stats into `teamsFromStats` (real names), check whether all entries in `teamStatsFromDb` (built from `v_game_detail`, may have wrong names) match a real team name. If not, remap each mismatched entry by score-matching `tot_spoints` → `updatedTeamsInfo` so that `teamStatsFromDb.find(ts => ts.name === team)` succeeds and the team-level summary stats are populated correctly.

## Files changed
- `client/src/components/InlineGameDetail.tsx`
- `client/src/components/GameDetailModal.tsx`

Replit-Task-Id: 0c1d1450-d572-46b0-a3aa-379000a865ac