### PR TITLE
Fix: Always show player photo regardless of which child-league record…

### DIFF
--- a/client/src/components/PlayerProfileContent.tsx
+++ b/client/src/components/PlayerProfileContent.tsx
@@ -1066,6 +1066,24 @@ export function PlayerProfileContent({ playerSlug, brandColorOverride, onBack, l
 
         const canonicalName = getMostCompleteName(variations);
 
+        // In parent leagues (e.g. REBA SL) the same physical player has one
+        // row per age-group competition. Only one row typically has
+        // photo_path_bg_removed set — whichever competition received the
+        // upload first. If the slug resolved to the photo-less record, scan
+        // all fuzzy-matched rows and use the first photo we find so the
+        // banner always renders the photo regardless of which record was
+        // clicked.
+        const photoSourceRecord = matchingPlayers.find(p => p.photo_path_bg_removed) ?? null;
+        const bestPhotoBgRemoved: string | null = photoSourceRecord?.photo_path_bg_removed ?? null;
+        const bestPhotoPath: string | null =
+          matchingPlayers.find(p => p.photo_path)?.photo_path ?? null;
+        // Use the focus-Y from whichever record owns the photo so the crop
+        // position is always in sync with the image being displayed.
+        const bestPhotoFocusY: number | null =
+          initialPlayer.photo_path_bg_removed
+            ? (initialPlayer.photo_focus_y ?? null)
+            : (photoSourceRecord?.photo_focus_y ?? null);
+
         let pInfo = {
           name: canonicalName,
           team: initialPlayer.team_name || initialPlayer.team,
@@ -1073,9 +1091,9 @@ export function PlayerProfileContent({ playerSlug, brandColorOverride, onBack, l
           number: initialPlayer.shirtNumber ?? initialPlayer.number,
           leagueId: initialPlayer.league_id,
           playerId: initialPlayer.id,
-          photoPath: initialPlayer.photo_path_bg_removed,
-          sharePhotoPath: initialPlayer.photo_path,
-          photoFocusY: initialPlayer.photo_focus_y,
+          photoPath: initialPlayer.photo_path_bg_removed || bestPhotoBgRemoved,
+          sharePhotoPath: initialPlayer.photo_path || bestPhotoPath,
+          photoFocusY: bestPhotoFocusY,
           height: initialPlayer.height || null,
           heightCm: initialPlayer.height_cm || null,
           dateOfBirth: initialPlayer.date_of_birth || null,


### PR DESCRIPTION
… opens

## Task
Task #264 — Player profile banners in parent leagues (e.g. REBA SL) could show a blank banner when the slug resolved to a child-league record that had no photo_path_bg_removed set, even though another matched record did have a photo.

## Root cause
In `PlayerProfileContent.tsx`, `pInfo.photoPath` was set solely from `initialPlayer.photo_path_bg_removed` — the single DB row resolved by the clicked slug. In parent leagues, the same physical player has one row per age-group competition, but only the row that first received a photo upload has `photo_path_bg_removed` set. Clicking a player from a different age-group tab resolved a different slug → a photo-less row → blank banner.

## Fix (PlayerProfileContent.tsx ~line 1072–1099)
After `matchingPlayers` is built (the full set of fuzzy-matched + identity- linked player rows), we now scan all of them for the first non-null `photo_path_bg_removed`, `photo_path`, and `photo_focus_y`:

  - `photoPath:  initialPlayer.photo_path_bg_removed || bestPhotoBgRemoved`
  - `sharePhotoPath: initialPlayer.photo_path || bestPhotoPath`
  - `photoFocusY`: taken from whichever record actually owns the photo so the crop position stays in sync with the displayed image.

All subsequent `setPlayerInfo(pInfo)` calls use `{ ...pInfo, ... }` spreads, so the photo fields are never wiped by a filter-change or stats-enrichment pass.

## No regressions
- Single-record players: `bestPhotoBgRemoved` will equal `initialPlayer.photo_path_bg_removed`, no change.
- `photo_focus_y` preference: primary record wins if it has a photo; sibling record's focus is used only when the primary has no photo.

Replit-Task-Id: 1c3fda12-ad45-4b51-974e-c77b485e20ab